### PR TITLE
PR_ Token de sesion dure mas tiempo

### DIFF
--- a/Web.config
+++ b/Web.config
@@ -18,7 +18,11 @@
     <compilation debug="true" targetFramework="4.7.2" />
     <httpRuntime targetFramework="4.7.2" />
     <customErrors mode="RemoteOnly" defaultRedirect="~/Content/img/ERROR-500-CABECERA.jpg"/>
-  </system.web>
+	  <authentication mode="Forms">
+		  <forms loginUrl="~/Acceso/Login" timeout="60" slidingExpiration="true" />
+	  </authentication>
+	  <sessionState timeout="60" />
+  </system.web>	
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>


### PR DESCRIPTION
1. Añadir configuración de autenticación en web.config:
Se agrega la sección de autenticación en el web.config,  causando que las sesiones de los usuarios expiren en un tiempo programado.

De la siguiente manera:
timeout: Establece la duración en minutos de la cookie de autenticación (en este ejemplo, 60 minutos).
slidingExpiration="true": Esto asegura que la cookie de autenticación se renueve automáticamente con cada solicitud dentro del tiempo de sesión activo.
#39