### PR TITLE
Cambio del formato de fecha en los comentarios

### DIFF
--- a/Controllers/TicketsController.cs
+++ b/Controllers/TicketsController.cs
@@ -1060,6 +1060,7 @@ namespace TAS360.Controllers
             sb.Append("");
             sb.AppendLine("-> Fecha: " + DateTime.Now.ToString("dd/MMMM/yyyy hh:mm:ss tt", new System.Globalization.CultureInfo("es-ES")));
             sb.AppendLine("-> Reportado por:" + ((User)Session["User"]).nombre);
+            sb.AppendLine("-> Versión: .....");
             sb.AppendLine("-> Reporte: .....");
             sb.AppendLine("..............");
             sb.AppendLine("-> Problematica: ");

--- a/Controllers/TicketsController.cs
+++ b/Controllers/TicketsController.cs
@@ -1058,11 +1058,11 @@ namespace TAS360.Controllers
             StringBuilder sb = new StringBuilder();
           
             sb.Append("");
-            sb.AppendLine("->Fecha: " + DateTime.Now);
-            sb.AppendLine("->Reportado por:" + ((User)Session["User"]).nombre);
-            sb.AppendLine("->Reporte: .....");
+            sb.AppendLine("-> Fecha: " + DateTime.Now.ToString("dd/MMMM/yyyy hh:mm:ss tt", new System.Globalization.CultureInfo("es-ES")));
+            sb.AppendLine("-> Reportado por:" + ((User)Session["User"]).nombre);
+            sb.AppendLine("-> Reporte: .....");
             sb.AppendLine("..............");
-            sb.AppendLine("->Problematica: ");
+            sb.AppendLine("-> Problematica: ");
             sb.AppendLine(".........");
             sb.AppendLine(".........");
             return sb.ToString();
@@ -1077,12 +1077,12 @@ namespace TAS360.Controllers
             StringBuilder sb = new StringBuilder();
 
             sb.Append("");
-            sb.AppendLine("->Fecha: " + DateTime.Now);
-            sb.AppendLine("->Reportado por:" + ((User)Session["User"]).nombre);
-            sb.AppendLine("->Reporte:");
+            sb.AppendLine("-> Fecha: " + DateTime.Now.ToString("dd/MMMM/yyyy hh:mm:ss tt", new System.Globalization.CultureInfo("es-ES")));
+            sb.AppendLine("-> Reportado por:" + ((User)Session["User"]).nombre);
+            sb.AppendLine("-> Reporte:");
             sb.AppendLine(".......");
             sb.AppendLine(".......");
-            sb.AppendLine("->Acciones a realizar: ");
+            sb.AppendLine("-> Acciones a realizar: ");
             sb.AppendLine(".........");
             sb.AppendLine(".........");
             return sb.ToString();


### PR DESCRIPTION
Se cambió el formato de la fecha en los comentarios de los tickets, tanto al crearlo como al agregar uno nuevo a dd/MMMM/yyyy hh:mm:ss (ejemplo: 16/octubre/2024 9:00:00 )