### PR TITLE
Feature 34 bug asignacion de usuario 

### DIFF
--- a/Controllers/TicketsController.cs
+++ b/Controllers/TicketsController.cs
@@ -705,8 +705,10 @@ namespace TAS360.Controllers
                         Ticket.id_Categoria = ticket.id_Categoria;
                         oLog.Add("Subsistema: " + Ticket.id_Subsistema);
                         Ticket.id_Subsistema = ticket.id_Subsistema;
-                        oLog.Add("Usuario: " + Ticket.id_User);
-                        Ticket.id_User = ((User)Session["User"]).id;
+                        oLog.Add("Usuario: " + ticket.id_Resp);
+                        Ticket.id_User = ticket.id_Resp;
+                        //oLog.Add("Usuario: " + Ticket.id_User);
+                        //Ticket.id_User = ((User)Session["User"]).id;
                         oLog.Add("Status: " + Ticket.status);
                         Ticket.status = ticket.Status;
                         oLog.Add("Mensaje: " + Ticket.mensaje);

--- a/Controllers/TicketsController.cs
+++ b/Controllers/TicketsController.cs
@@ -224,6 +224,7 @@ namespace TAS360.Controllers
                         idTicket = db.Ticket.FirstOrDefault(a => a.titulo == model.titulo && a.id_Terminal == model.id_Terminal && a.id_Categoria == model.id_Categoria && a.mensaje == model.mensaje).id;
                         oLog.Add("Se creo el Ticket: " + idTicket);
                         oLog.Add("Titulo del Ticket: " + model.titulo);
+                        oLog.Add("Usuario creador: " + ((User)Session["User"]).id);
                         oLog.Add("Usuario creador: " + ((User)Session["User"]).nombre);
                         if (idTicket != 0)
                         {
@@ -605,7 +606,9 @@ namespace TAS360.Controllers
                         
                         var Ticket = db.Ticket.Find(ticket.id);
                         oLog.Add("id_User: " + ticket.id_Resp);
-                        Ticket.id_User = ticket.id_Resp;
+                        ticket.id_Resp = Ticket.id_User;
+                        //Ticket.id_User = ticket.id_Resp;
+
                         db.Entry(Ticket).State = System.Data.Entity.EntityState.Modified;
                         db.SaveChanges();
                         //Logs


### PR DESCRIPTION
Se corrigen en TicketController  los métodos CreateTicket, EditTicket  y    AddCommentTicket para la correcto manejo de la variable Id_Resp la cual contiene el valor del id del usuario el cual tiene asignado un ticket, la variable se sustituye con la variable Id_User de las tablas Ticket y Ticket_User, siendo el Id_User el valor final donde se muestra el id asignado al ticket.

Querys usados para validacion de funcionamiento 
SELECT * FROM [ptstools_HelpDesk].[dbo].[Ticket]  where id =(numero Ticket)
SELECT * FROM [ptstools_HelpDesk].[dbo].[Ticket_User] where id_Ticket = (numero Ticket) order by  CreatedAt desc
Select * from [ptstools_HelpDesk].[dbo].[User] where nombre like '%(Nombre usuario)%'


Se hace referencia al Bug en la pantalla de IndexWithFilter de Tickets
[#34](https://github.com/julianMondragon/TAS360/issues/34)