### PR TITLE
17 paginación de tickets

### DIFF
--- a/Controllers/AccesoController.cs
+++ b/Controllers/AccesoController.cs
@@ -48,14 +48,7 @@ namespace TAS360.Controllers
                                     </div>
                                 </body>
                                 </html>";
-        
-        
-        
-        
-        
-        
-        
-        
+  
         // GET: Acceso
         public ActionResult Login()
         {

--- a/Controllers/TicketsController.cs
+++ b/Controllers/TicketsController.cs
@@ -20,8 +20,11 @@ using SpreadsheetLight;
 using DocumentFormat.OpenXml.Office2010.Excel;
 using System.Web.Services.Description;
 using System.EnterpriseServices.Internal;
+using X.PagedList;
+using X.PagedList.Mvc;
+using System.Web.Routing;
 
- 
+
 
 namespace TAS360.Controllers
 {
@@ -130,59 +133,98 @@ namespace TAS360.Controllers
             return View(tickets);
         }
         /// <summary>
-        /// Método que genera la lista de tickets filtrados para posteriormente enviarlos 
-        /// a la vista de IndexWithFilter
+        /// Método que aplica los filtros recibidos desde la URL para consultar los tickets, 
+        /// los transforma a TicketViewModel y los envía a la vista paginados.
         /// </summary>
         /// <param name="encodedCurrentList"></param>
         /// <returns></returns>
-        [AuthorizeUser(idOperacion: 5)]
-        public ActionResult IndexWithFilter(string encodedCurrentList)
-        {
-            // Inicializa la lista
-            List<TicketViewModel> model = new List<TicketViewModel>();
-            List<CurrentList> currentList = new List<CurrentList>();
-            // Decodifica el objeto que recibe
-            var decodedObject = HttpUtility.UrlDecode(encodedCurrentList);
-            currentList = JsonConvert.DeserializeObject<List<CurrentList>>(decodedObject);
-            // Aquí itera sobre cada elemento para crear la lista
-            foreach (var item in currentList)
-            {
-                item.is_selected = false;
-                // Se conecta a la bd
-                using (HelpDesk_Entities1 db = new HelpDesk_Entities1())
-                {
-                    // Busca el ticket correspondiente en la base de datos
-                    var t = db.Ticket.FirstOrDefault(tic => tic.id == item.id);
-                    if (t != null)
-                    {
-                        // Busca el usuario asociado al ticket
-                        var User = db.User.FirstOrDefault(usr => usr.id == t.id_User);
-                        // Va añadiendo a la lista cada TicketViewModel de los tickets existentes
-                        model.Add(new TicketViewModel
-                            ()
-                        {
-                            id = t.id,
-                            titulo = t.titulo,
-                            mensaje = t.mensaje,
-                            usuario_name = User != null ? User.nombre : "Usuario no encontrado",
-                            categoria_name = t.Categoria != null ? t.Categoria.nombre : "Categoría no encontrada",
-                            terminal_name = t.Terminal != null ? t.Terminal.Nombre : "Terminal no encontrada",
-                            status_name = t.Ticket_Record_Status.OrderByDescending(x => x.CreatedAt).FirstOrDefault()?.Status.descripcion ?? "Estado no encontrado",
-                            Subsistema_name = t.Subsistema != null ? t.Subsistema.Nombre : "Subsistema no encontrado",
-                            Status = t.status,
-                            currentList = currentList
-                        });
-                    }                    
-                }
-            }
-            // Serializa y codifica la lista de tickets filtrados
-            var serializedObject = JsonConvert.SerializeObject(currentList);
-            encodedCurrentList = HttpUtility.UrlEncode(serializedObject);
 
-            // Pasa la lista codificada a la vista
-            ViewBag.EncodedCurrentList = encodedCurrentList;
-            // Devuelve la vista con la lista de modelos de tickets
-            return View(model);
+        [AuthorizeUser(idOperacion: 5)]
+        public ActionResult IndexWithFilter(
+            int? page,
+            int? id,
+            int? id_Terminal,
+            int? id_Categoria,
+            int? id_Subsistema,
+            int? status,
+            int? id_User,
+            bool? just_closed,
+            bool? is_closed)
+        {
+            using (HelpDesk_Entities1 db = new HelpDesk_Entities1())
+
+            {
+                var ticketsQuery = db.Ticket.AsQueryable();
+
+                // Aplicar filtro por ID si se seleccionó
+                if (id.HasValue)
+                {
+                    ticketsQuery = ticketsQuery.Where(t => t.id == id.Value);
+                }
+                // Aplicar filtro por Terminal
+                if (id_Terminal.HasValue)
+                {
+                    ticketsQuery = ticketsQuery.Where(t => t.id_Terminal == id_Terminal.Value);
+                }
+                // Aplicar filtro por Categoría
+                if (id_Categoria.HasValue)
+                {
+                    ticketsQuery = ticketsQuery.Where(t => t.id_Categoria == id_Categoria.Value);
+                }
+                // Aplicar filtro por Subsistema
+                if (id_Subsistema.HasValue)
+                {
+                    ticketsQuery = ticketsQuery.Where(t => t.id_Subsistema == id_Subsistema.Value);
+                }
+                // Aplicar filtro por Estatus
+                if (status.HasValue)
+                {
+                    ticketsQuery = ticketsQuery.Where(t => t.status == status.Value);
+                }
+                // Aplicar filtro por Usuario
+                if (id_User.HasValue)
+                {
+                    ticketsQuery = ticketsQuery.Where(t => t.id_User == id_User.Value);
+                }
+                // Aplicar la lógica de tickets cerrados
+                if (just_closed.HasValue && just_closed.Value)
+                {
+                    ticketsQuery = ticketsQuery.Where(t => t.status == 12);
+                }
+                else if (!(is_closed.HasValue && is_closed.Value))
+                {
+                    // Si no se selecciona incluir tickets cerrados (is_closed = true), se excluyen los cerrados.
+                    ticketsQuery = ticketsQuery.Where(t => t.status != 12);
+                }
+
+                // Traer la lista de tickets
+                var ticketViewModel = ticketsQuery.ToList().Select(t => new TicketViewModel
+                {
+                    id = t.id,
+                    titulo = t.titulo,
+                    status_name = GetStatusName(t.status),
+                    usuario_name = GetUsuarioName(t.id_User),
+                    Subsistema_name = GetSubsistemaName(t.id_Subsistema),
+                    terminal_name = GetTerminalName(t.id_Terminal),
+                    categoria_name = GetCategoriaName(t.id_Categoria)
+                }).ToList();
+
+                int pageSize = 10;
+                int pageNumber = page ?? 1;
+                var pagedTickets = ticketViewModel.ToPagedList(pageNumber, pageSize);
+
+                // Guardar los parámetros de filtro para la paginación
+                ViewBag.id = id;
+                ViewBag.id_Terminal = id_Terminal;
+                ViewBag.id_Categoria = id_Categoria;
+                ViewBag.id_Subsistema = id_Subsistema;
+                ViewBag.status = status;
+                ViewBag.id_User = id_User;
+                ViewBag.just_closed = just_closed;
+                ViewBag.is_closed = is_closed;
+
+                return View(pagedTickets);
+            }
         }
 
         /// <summary>
@@ -927,6 +969,22 @@ namespace TAS360.Controllers
             ViewBag.Categorias = Categorias;
         }
 
+        private string GetCategoriaName(int? id_Categoria)
+        {
+            if (id_Categoria == null)
+                return "Categoria no encontrada";
+
+            using (HelpDesk_Entities1 db = new HelpDesk_Entities1())
+            {
+                var Categoria = db.Categoria
+                    .Where(s => s.id == id_Categoria)
+                    .Select(s => s.nombre)
+                    .FirstOrDefault();
+
+                return Categoria ?? "Categoria no encontrada";
+            }
+        }
+
         /// <summary>
         /// Devuelve a la vista una lista de las Terminales del ticket 
         /// </summary>
@@ -961,6 +1019,22 @@ namespace TAS360.Controllers
 
         }
 
+        private string GetTerminalName(int? id_Terminal)
+        {
+            if (id_Terminal == null)
+                return "Terminal no encontrada"; 
+
+            using (HelpDesk_Entities1 db = new HelpDesk_Entities1())
+            {
+                var terminal = db.Terminal
+                    .Where(t => t.id == id_Terminal) 
+                    .Select(t => t.Nombre)          
+                    .FirstOrDefault(); 
+
+                return terminal ?? "Terminal no encontrada";
+            }
+        }
+
         /// <summary>
         /// Devuelve a la vista una lista de los usuarios especialistas tecnicos 
         /// </summary>
@@ -986,6 +1060,22 @@ namespace TAS360.Controllers
             }
             ViewBag.Usuarios = Usuarios;
 
+        }
+
+        private string GetUsuarioName(int? id_User)
+        {
+            if (id_User == null)
+                return "Usuario desconocido";
+
+            using (HelpDesk_Entities1 db = new HelpDesk_Entities1())
+            {
+                var usuario = db.User
+                    .Where(u => u.id == id_User) 
+                    .Select(u => u.nombre)      
+                    .FirstOrDefault();  
+
+                return usuario ?? "Usuario no encontrado";
+            }
         }
 
         /// <summary>
@@ -1026,6 +1116,23 @@ namespace TAS360.Controllers
             }
             ViewBag.Status = Status;
 
+        }
+
+
+        private string GetStatusName(int? status)
+        {
+            if (status == null)
+                return "Sin estado"; // Si el estado es nulo, devolvemos un valor por defecto
+
+            using (HelpDesk_Entities1 db = new HelpDesk_Entities1())
+            {
+                var estado = db.Status
+                    .Where(s => s.Status1 == status)
+                    .Select(s => s.descripcion)
+                    .FirstOrDefault();
+
+                return estado ?? "Estado desconocido";
+            }
         }
 
         /// <summary>
@@ -1095,6 +1202,22 @@ namespace TAS360.Controllers
 
         }
 
+        private string GetSubsistemaName(int? id_Subsistema)
+        {
+            if (id_Subsistema == null)
+                return "Subsistema no encontrado";
+
+            using (HelpDesk_Entities1 db = new HelpDesk_Entities1())
+            {
+                var subsistema = db.Subsistema
+                    .Where(s => s.id == id_Subsistema) 
+                    .Select(s => s.Nombre)
+                    .FirstOrDefault();
+
+                return subsistema ?? "Subsistema no encontrado";
+            }
+        }
+
         /// <summary>
         /// Devuelve a la vista un templete para redactar el ticket
         /// </summary>
@@ -1155,161 +1278,141 @@ namespace TAS360.Controllers
 
 
         /// <summary>
-        /// Este metodo obtiene los datos de los tickets existentes
+        /// Este metodo obtiene los datos de los tickets existentes e 
+        /// inicializar las listas desplegables (terminales, estatus, subsistemas, etc.)
+        /// para mostrar el formulario al usuario.
         /// </summary>
         /// <returns> FilterTicketsViewModel </returns>
         [HttpGet]
         [AuthorizeUser(idOperacion: 23)]
         public ActionResult Filter_Tickets()
         {
-            FilterTicketsViewModel Filter = new FilterTicketsViewModel() { id_Terminal = 1};
+            FilterTicketsViewModel filter = new FilterTicketsViewModel() { id_Terminal = 1 };
             GetTerminales();
             GetSubsistemas();
             GetStatus(1);
             GetCategories();
             GetUsuarios();
-            return View(Filter);
+            return View(filter);
         }
 
         /// <summary>
-        /// Devuelve a la vista un objeto para filtrar el ticket
+        /// Valida los filtros seleccionados, y construye una URL que los incluya, 
+        /// para que IndexWithFilter pueda usarlos al mostrar resultados.
+        /// Devuelviendole un objeto para filtrar el ticket con paginación.
         /// </summary>
         /// <param name="Filter"></param>
+        /// <param name="page"></param>
         /// <returns></returns>
+
         [HttpPost]
         [AuthorizeUser(idOperacion: 23)]
-        public ActionResult Filter_Tickets(FilterTicketsViewModel Filter)
+        public ActionResult Filter_Tickets(FilterTicketsViewModel Filter, int? page)
         {
+            // Cargar listas necesarias para los dropdowns en la vista
             GetTerminales();
             GetSubsistemas();
             GetStatus(1);
             GetCategories();
             GetUsuarios();
-            //se declara la lista que sera llenada con el resultado del filtro
-            List<ListbyFilterTicket> currentLists = new List<ListbyFilterTicket>();
 
-            if (ModelState.IsValid) //Valida el modelo
+            if (!ModelState.IsValid)
             {
-                if (Filter.just_closed && Filter.is_closed)
-                {
-                    //devuelve a la vista el modelo y un mensaje de busqueda sin resultados
-                    ViewBag.warning = "Query Error: No puedes seleccionar los dos ultimos checkbox juntos para realizar una busqueda ";
-                    return View(Filter);
-                }
-                using (HelpDesk_Entities1 db = new HelpDesk_Entities1())
-                {
-                    if (Filter.isSelected_id) //si el Id fue seleccionado
-                    {
-                        //realiza la busqueda por el ID
-                        Ticket filter = db.Ticket.Find(Filter.id);
-                        if (filter == null) // si la busqueda por el id es null
-                        {
-                            //devuelve a la vista el modelo y un mensaje de busqueda sin resultados
-                            ViewBag.warning = "Ningun registro coicide con el id: " + Filter.id;
-                            return View(Filter);
-                        }
-                        //agrega a la lista en curso 
-                        currentLists.Add(new ListbyFilterTicket() { id = filter.id });
-                    }
-                    else
-                    {
-                        var listFilter = new List<Ticket>();
-
-                        if (Filter.is_closed)
-                        {
-                            listFilter = db.Ticket.Take(92).ToList();
-                        }
-                        else if (Filter.just_closed)
-                        {
-                            listFilter = db.Ticket.Where(x => x.status == 12).Take(92).ToList();
-                        }
-                        else
-                        {
-                            listFilter = db.Ticket.Where(x => x.status != 12).Take(92).ToList();
-                        }
-                        if (Filter.isSelected_Terminal)
-                        {
-                            listFilter = listFilter.Where(t => t.id_Terminal == Filter.id_Terminal).ToList();
-                            if (listFilter.Count() < 1)
-                            {
-                                //devuelve a la vista el modelo y un mensaje de busqueda sin resultados
-                                ViewBag.warning = "Ningun registro coicide con la terminal: " + Filter.id_Terminal;
-                                return View(Filter);
-
-                            }
-                        }
-                        if (Filter.isSelected_Categ)
-                        {
-                            listFilter = listFilter.Where(t => t.id_Categoria == Filter.id_Categoria).ToList();
-                            if (listFilter.Count() < 1)
-                            {
-                                //devuelve a la vista el modelo y un mensaje de busqueda sin resultados
-                                ViewBag.warning = "Ningun registro coicide con la Categoría: " + Filter.id_Categoria;
-                                return View(Filter);
-
-                            }
-                        }
-                        if (Filter.isSelected_subsistema)
-                        {
-                            listFilter = listFilter.Where(t => t.id_Subsistema == Filter.id_Subsistema).ToList();
-                            if (listFilter.Count() < 1)
-                            {
-                                //devuelve a la vista el modelo y un mensaje de busqueda sin resultados
-                                ViewBag.warning = "Ningun registro coicide con el Subsistema: " + Filter.id_Subsistema;
-                                return View(Filter);
-
-                            }
-                        }
-                        if (Filter.isSelected_Status)
-                        {
-                            listFilter = listFilter.Where(t => t.status == Filter.status).ToList();
-                            if (listFilter.Count() < 1)
-                            {
-                                //devuelve a la vista el modelo y un mensaje de busqueda sin resultados
-                                ViewBag.warning = "Ningun registro coicide con el estatus: " + Filter.status;
-                                return View(Filter);
-
-                            }
-                        }
-
-                        if (Filter.isSelected_User)
-                        {
-                            //Aquí también se establece un límite de 40 tickets a enviar a la lista de la vista
-                            listFilter = listFilter.Where(t => t.id_User == Filter.id_User).Take(40).ToList();
-                            if (listFilter.Count() < 1)
-                            {
-                                //devuelve a la vista el modelo y un mensaje de busqueda sin resultados
-                                ViewBag.warning = "Ningun registro coicide con usuario: " + Filter.id_User;
-                                return View(Filter);
-
-                            }
-                        }
-
-                        //el resultado de la busqueda
-                        foreach (var item in listFilter)
-                        {
-                            currentLists.Add(new ListbyFilterTicket() { id = item.id });
-                        }
-                    }
-                }
-            }
-            else
-            {
-                ViewBag.warning = "Filtro no valido";
+                ViewBag.warning = "El filtro no es válido";
                 return View(Filter);
             }
 
-            // Objeto a enviar
-            string encodedCurrentList = "";
-            // Serialización y codificación
-            var serializedObject = JsonConvert.SerializeObject(currentLists);
-            encodedCurrentList = HttpUtility.UrlEncode(serializedObject);
-            // Creación de la URL con la cadena de consulta
-            var url = "IndexWithFilter/?encodedCurrentList=" + encodedCurrentList;
-            // Redirecciona a la URL 
-            return Redirect(url);
-            //return View("IndexWithFilter", encodedCurrentList);
+            if (Filter.just_closed && Filter.is_closed)
+            {
+                ViewBag.warning = "Query Error: No puedes seleccionar ambos checkbox a la vez.";
+                return View(Filter);
+            }
+
+            //Verificar si hay resultados del filtro
+            using (HelpDesk_Entities1 db = new HelpDesk_Entities1())
+            {
+                var ticketsQuery = db.Ticket.AsQueryable();
+
+                if (Filter.isSelected_id && Filter.id.HasValue)
+                    ticketsQuery = ticketsQuery.Where(t => t.id == Filter.id.Value);
+
+                if (Filter.isSelected_Terminal && Filter.id_Terminal.HasValue)
+                    ticketsQuery = ticketsQuery.Where(t => t.id_Terminal == Filter.id_Terminal.Value);
+
+                if (Filter.isSelected_Categ && Filter.id_Categoria.HasValue)
+                    ticketsQuery = ticketsQuery.Where(t => t.id_Categoria == Filter.id_Categoria.Value);
+
+                if (Filter.isSelected_subsistema && Filter.id_Subsistema.HasValue)
+                    ticketsQuery = ticketsQuery.Where(t => t.id_Subsistema == Filter.id_Subsistema.Value);
+
+                if (Filter.isSelected_Status && Filter.status.HasValue)
+                    ticketsQuery = ticketsQuery.Where(t => t.status == Filter.status.Value);
+
+                if (Filter.isSelected_User && Filter.id_User.HasValue)
+                    ticketsQuery = ticketsQuery.Where(t => t.id_User == Filter.id_User.Value);
+
+                if (Filter.just_closed)
+                    ticketsQuery = ticketsQuery.Where(t => t.status == 12);
+                else if (!Filter.is_closed)
+                    ticketsQuery = ticketsQuery.Where(t => t.status != 12);
+
+                if (!ticketsQuery.Any())
+                {
+                    ViewBag.warning = "No se encontraron resultados para la selección del filtro.";
+                    return View(Filter);
+                }
+            }
+
+            // Construir los valores de ruta (query string) con los filtros seleccionados
+            var routeValues = new RouteValueDictionary();
+
+            // Si se filtra por ID
+            if (Filter.isSelected_id && Filter.id.HasValue)
+            {
+                routeValues["id"] = Filter.id;
+            }
+            // Filtrar por Terminal (TADs)
+            if (Filter.isSelected_Terminal && Filter.id_Terminal.HasValue)
+            {
+                routeValues["id_Terminal"] = Filter.id_Terminal;
+            }
+            // Filtrar por Categoría
+            if (Filter.isSelected_Categ && Filter.id_Categoria.HasValue)
+            {
+                routeValues["id_Categoria"] = Filter.id_Categoria;
+            }
+            // Filtrar por Subsistema
+            if (Filter.isSelected_subsistema && Filter.id_Subsistema.HasValue)
+            {
+                routeValues["id_Subsistema"] = Filter.id_Subsistema;
+            }
+            // Filtrar por Estatus
+            if (Filter.isSelected_Status && Filter.status.HasValue)
+            {
+                routeValues["status"] = Filter.status;
+            }
+            // Filtrar por Usuario
+            if (Filter.isSelected_User && Filter.id_User.HasValue)
+            {
+                routeValues["id_User"] = Filter.id_User;
+            }
+
+            // Pasar los booleanos de tickets cerrados
+            routeValues["just_closed"] = Filter.just_closed;
+            routeValues["is_closed"] = Filter.is_closed;
+
+            // Se puede incluir la página (opcional)
+            if (page.HasValue)
+            {
+                routeValues["page"] = page.Value;
+            }
+
+            // Redirigir a la acción GET que muestra los resultados filtrados
+            return RedirectToAction("IndexWithFilter", routeValues);
         }
+
+
+
 
         /// <summary>
         /// Metodo que se encarga de exportar la tabla tickets

--- a/TAS360.csproj
+++ b/TAS360.csproj
@@ -140,6 +140,9 @@
       <HintPath>packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
+    <Reference Include="X.PagedList, Version=10.5.7.0, Culture=neutral, PublicKeyToken=525ccaa9023f010c, processorArchitecture=MSIL">
+      <HintPath>packages\X.PagedList.10.5.7\lib\netstandard2.0\X.PagedList.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">

--- a/TAS360.csproj
+++ b/TAS360.csproj
@@ -79,6 +79,11 @@
     <Reference Include="System.IO.Packaging, Version=4.0.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.IO.Packaging.4.7.0\lib\net46\System.IO.Packaging.dll</HintPath>
     </Reference>
+    <Reference Include="System.Linq.Expressions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Linq.Expressions.4.3.0\lib\net463\System.Linq.Expressions.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Management" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
@@ -140,8 +145,11 @@
       <HintPath>packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
-    <Reference Include="X.PagedList, Version=10.5.7.0, Culture=neutral, PublicKeyToken=525ccaa9023f010c, processorArchitecture=MSIL">
-      <HintPath>packages\X.PagedList.10.5.7\lib\netstandard2.0\X.PagedList.dll</HintPath>
+    <Reference Include="X.PagedList, Version=7.6.0.0, Culture=neutral, PublicKeyToken=00b6c4f97602e5e8, processorArchitecture=MSIL">
+      <HintPath>packages\X.PagedList.7.6.0\lib\net461\X.PagedList.dll</HintPath>
+    </Reference>
+    <Reference Include="X.PagedList.Mvc, Version=7.6.0.0, Culture=neutral, PublicKeyToken=c6e0b5b21f916f4f, processorArchitecture=MSIL">
+      <HintPath>packages\X.PagedList.Mvc.7.6.0\lib\net461\X.PagedList.Mvc.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Views/Tickets/Filter_Tickets.cshtml
+++ b/Views/Tickets/Filter_Tickets.cshtml
@@ -19,27 +19,50 @@
     <h1 class="section-heading mb-4">
         <span class="section-heading-lower">Filtrar tickets por: </span>
     </h1>
-    <p class="lead">
-       En esta ventana podrás realizar filtrado de tickets seleccionando el checkbox de cada propiedad.
-    </p>
+
     @if (exception != null)
     {
-        <div class="alert alert-danger" role="alert">
+        <div class="alert alert-danger mt-3" role="alert">
             @exception
         </div>
     }
     @if (Info != null)
     {
-        <div class="alert alert-info" role="alert">
+        <div class="alert alert-info mt-3" role="alert">
             @Info
         </div>
     }
     @if (warning != null)
     {
-        <div class="alert alert-warning" role="alert">
+        <div class="alert alert-warning mt-3" role="alert">
             @warning
         </div>
     }
+</div>
+
+<div class="alert alert-info" role="alert">
+    <h4 class="alert-heading">¿Cómo funciona el filtrado de tickets?</h4>
+    <p>
+        Puedes aplicar múltiples filtros para buscar tickets específicos. Marca los <strong>checkboxes</strong> que quieras activar
+        (como ID, Usuario, Terminal, etc.), y selecciona sus valores correspondientes.
+    </p>
+    <hr />
+    <ul>
+        <li><strong>Los filtros se combinan</strong>: se mostrarán solo los tickets que cumplan <u>todas</u> las condiciones marcadas.</li>
+        <li><strong>Ejemplo 1:</strong> Si eliges <em>ID = 23</em> y <em>Terminal = TAD Hermosillo</em>, se mostrará el ticket 23 solo si pertenece a esa terminal.</li>
+        <li><strong>Ejemplo 2:</strong> Si seleccionas <em>Usuario = Carter</em> y <em>Terminal = TAD Hermosillo</em>, verás solo los tickets de Carter en esa terminal.</li>
+        <li>Si no hay coincidencias con los filtros marcados, <strong>no se mostrará ningún ticket</strong>.</li>
+    </ul>
+    <hr />
+    <p>
+        Además, puedes usar las siguientes opciones para incluir tickets cerrados:
+    </p>
+    <ul>
+        <li><strong>Incluir Tickets cerrados</strong>: Agrega al resultado los tickets que ya fueron finalizados.</li>
+        <li><strong>Solo Tickets cerrados</strong>: Muestra <u>únicamente</u> los tickets que están cerrados.</li>
+    </ul>
+</div>
+
 </div>
 <section class="page-section about-heading">
     <div class="container">

--- a/Views/Tickets/IndexWithFilter.cshtml
+++ b/Views/Tickets/IndexWithFilter.cshtml
@@ -1,94 +1,80 @@
 ﻿@using System.Collections.Generic;
 @using TAS360.Models.ViewModel;
 @using Newtonsoft.Json;
-@model List<TAS360.Models.ViewModel.TicketViewModel>
-@{
-    ViewBag.Title = "Tickets filtrados del TAS360"; // Establece el título de la página
+@using X.PagedList
+@using X.PagedList.Mvc
+@model IPagedList<TAS360.Models.ViewModel.TicketViewModel>
 
-    string encodedCurrentList = "";// Inicializa la variable para almacenar la lista para el URL
-    //Serializa y posteriormente codifica el objeto a enviar
-    var serializedObject = JsonConvert.SerializeObject(Model.FirstOrDefault().CurrentList2);
-    encodedCurrentList = HttpUtility.UrlEncode(serializedObject);
+@{
+    ViewBag.Title = "Tickets filtrados del TAS360";
 }
 
 <div class="jumbotron">
     <h1>Lista de Tickets filtrados</h1>
     <p class="lead">
-        @if (@Model.Count() < 90)
-        {
-            <text>Se muestran @Model.Count() resultados para el filtro aplicado.</text>
-        }
-        else
-        {
-            <text>Solo se muestran los primeros 90 resultados de tu filtro , puedes agregar mas criterios de busqueda para encontrar el ticket que deseado.</text>
-        }
+        Se muestran los resultados para el filtro aplicado.
     </p>
     <div class="row">
-        @*Estos botones redirigen a otras acciones dentro del Ticket Controller*@
-        <button onclick="document.location.href = '@Url.Content("~/Tickets/CreateTicket")'" type="button" class="btn btn-success" data-toggle="tooltip" title="se abrirá un formulario para crear un Ticket">
+        <button onclick="document.location.href = '@Url.Content("~/Tickets/CreateTicket")'" class="btn btn-success">
             Crear un Ticket &raquo;
         </button>
-        <button onclick="document.location.href = '@Url.Content("~/Tickets/Filter_Tickets")'" type="button" class="btn btn-warning" data-toggle="tooltip" title="Realiza un filtrado personalizado de los Tickets ">
+        <button onclick="document.location.href = '@Url.Content("~/Tickets/Filter_Tickets")'" class="btn btn-warning">
             Filtrado &fnof;
         </button>
-        <button onclick="document.location.href = '@Url.Content("~/Tickets/ExportTableTickets/?encodedCurrentList=" + ViewBag.EncodedCurrentList)'" type="button" class="btn btn-info" data-toggle="tooltip" title="Exporta la tabla actual ">
+        <button onclick="document.location.href = '@Url.Content("~/Tickets/ExportTableTickets")'" class="btn btn-info">
             Exportar &pound;
         </button>
     </div>
-
 </div>
+
 <div class="row">
     <div class="col-md-12">
         <table class="table table-success table-striped table-bordered">
             <thead class="thead-dark">
                 <tr>
-                    <th colspan="1" scope="col">Id</th>
-                    <th colspan="1" scope="col">Titulo</th>
-                    <th colspan="1" scope="col">Status</th>
-                    <th colspan="2" scope="col">Usuario</th>
-                    <th colspan="1">Subsistema</th>
-                    <th colspan="1">Terminal</th>
-                    <th colspan="1">Acciones</th>
+                    <th>Id</th>
+                    <th>Titulo</th>
+                    <th>Status</th>
+                    <th>Usuario</th>
+                    <th>Subsistema</th>
+                    <th>Terminal</th>
+                    <th>Acciones</th>
                 </tr>
-
             </thead>
             <tbody>
-                @*Llena la tabla con las columnas id, categoría, usuario, subsistema, terminal y los botones para mostrar y editar ticket*@
-                @if (Model != null)
+                @foreach (var Ticket in Model)
                 {
-                    foreach (var Ticket in Model)
-                    {
-                        <tr>
-                            <td colspan="1"> @Ticket.id</td>
-                            <td colspan="1"> @Ticket.titulo</td>
-                            <td colspan="1"> @Ticket.status_name</td>
-                            <td colspan="2"> @Ticket.usuario_name</td>
-                            <td colspan="1"> @Ticket.Subsistema_name</td>
-                            <td colspan="1"> @Ticket.terminal_name</td>
-                            <td colspan="1">
-                                @if (Ticket.Status == 12)
-                                {
-                                    <button onclick="document.location.href = '@Url.Content("~/Tickets/ShowTicket/" + Ticket.id)'" class="btn btn-default" data-toggle="tooltip" title="Detalles el Ticket">
-                                        <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512"><path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z" /></svg>
-                                    </button>
-                                }
-                                else
-                                {
-                                    <button onclick="document.location.href = '@Url.Content("~/Tickets/ShowTicket/" + Ticket.id)'" class="btn btn-default" data-toggle="tooltip" title="Detalles el Ticket">
-                                        <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512"><path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z" /></svg>
-                                    </button>
-                                    <button onclick="document.location.href = '@Url.Content("~/Tickets/EditTicket/" + Ticket.id)'" class="btn btn-primary" data-toggle="tooltip" title="Editar el Ticket">
-                                        <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512"><path d="M471.6 21.7c-21.9-21.9-57.3-21.9-79.2 0L362.3 51.7l97.9 97.9 30.1-30.1c21.9-21.9 21.9-57.3 0-79.2L471.6 21.7zm-299.2 220c-6.1 6.1-10.8 13.6-13.5 21.9l-29.6 88.8c-2.9 8.6-.6 18.1 5.8 24.6s15.9 8.7 24.6 5.8l88.8-29.6c8.2-2.7 15.7-7.4 21.9-13.5L437.7 172.3 339.7 74.3 172.4 241.7zM96 64C43 64 0 107 0 160V416c0 53 43 96 96 96H352c53 0 96-43 96-96V320c0-17.7-14.3-32-32-32s-32 14.3-32 32v96c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V160c0-17.7 14.3-32 32-32h96c17.7 0 32-14.3 32-32s-14.3-32-32-32H96z" /></svg>
-                                    </button>
-                                }
-
-                            </td>
-                        </tr>
-                    }
+                    <tr>
+                        <td>@Ticket.id</td>
+                        <td>@Ticket.titulo</td>
+                        <td>@Ticket.status_name</td>
+                        <td>@Ticket.usuario_name</td>
+                        <td>@Ticket.Subsistema_name</td>
+                        <td>@Ticket.terminal_name</td>
+                        <td>
+                            <button onclick="document.location.href = '@Url.Content("~/Tickets/ShowTicket/" + Ticket.id)'" class="btn btn-default" data-toggle="tooltip" title="Detalles el Ticket">
+                                <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512"><path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336h24V272H216c-13.3 0-24-10.7-24-24s10.7-24 24-24h48c13.3 0 24 10.7 24 24v88h8c13.3 0 24 10.7 24 24s-10.7 24-24 24H216c-13.3 0-24-10.7-24-24s10.7-24 24-24zm40-208a32 32 0 1 1 0 64 32 32 0 1 1 0-64z" /></svg> Ver
+                            </button>
+                        </td>
+                    </tr>
                 }
             </tbody>
         </table>
+
+        <!-- Controles de paginación con los filtros en la URL -->
+        <div class="text-center">
+            @Html.PagedListPager(Model, page => Url.Action("IndexWithFilter", new
+            {
+                page,
+                id = ViewBag.id,
+                id_Terminal = ViewBag.id_Terminal,
+                id_Categoria = ViewBag.id_Categoria,
+                id_Subsistema = ViewBag.id_Subsistema,
+                status = ViewBag.status,
+                id_User = ViewBag.id_User,
+                just_closed = ViewBag.just_closed,
+                is_closed = ViewBag.is_closed
+            }))
+        </div>
     </div>
 </div>
-
-

--- a/Views/Web.config
+++ b/Views/Web.config
@@ -17,6 +17,8 @@
         <add namespace="System.Web.Mvc.Html" />
         <add namespace="System.Web.Optimization"/>
         <add namespace="System.Web.Routing" />
+		<add namespace="X.PagedList"/>
+        <add namespace="X.PagedList.Mvc"/>
         <add namespace="TAS360" />
       </namespaces>
     </pages>

--- a/Web.config
+++ b/Web.config
@@ -17,7 +17,7 @@
   <system.web>
     <compilation debug="true" targetFramework="4.7.2" />
     <httpRuntime targetFramework="4.7.2" />
-    <customErrors mode="RemoteOnly" defaultRedirect="~/Content/img/ERROR-500-CABECERA.jpg"/>
+    <customErrors mode="RemoteOnly" defaultRedirect="~/Content/img/ERROR-500-CABECERA.jpg" />
 	  <authentication mode="Forms">
 		  <forms loginUrl="~/Acceso/Login" timeout="60" slidingExpiration="true" />
 	  </authentication>

--- a/packages.config
+++ b/packages.config
@@ -26,4 +26,5 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net472" />
   <package id="System.IO.Packaging" version="4.7.0" targetFramework="net472" />
   <package id="WebGrease" version="1.6.0" targetFramework="net472" />
+  <package id="X.PagedList" version="10.5.7" targetFramework="net472" />
 </packages>

--- a/packages.config
+++ b/packages.config
@@ -25,6 +25,9 @@
   <package id="System.Drawing.Common" version="5.0.0" targetFramework="net472" />
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net472" />
   <package id="System.IO.Packaging" version="4.7.0" targetFramework="net472" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Linq.Queryable" version="4.3.0" targetFramework="net472" />
   <package id="WebGrease" version="1.6.0" targetFramework="net472" />
-  <package id="X.PagedList" version="10.5.7" targetFramework="net472" />
+  <package id="X.PagedList" version="7.6.0" targetFramework="net472" />
+  <package id="X.PagedList.Mvc" version="7.6.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
**Se realizan cambios en:**
-Packages.config
-TAS360.csproj
-Web.config (Views)
-AccesoController.cs
-TicketsController.cs
-Filter_Tickets
-Tickets_Controller

En **Packages.config, TAS360.csproj y Web.config** (de Views) se realizan cambios para incorporar los paquetes/librerías para poder hacer la paginación del índice de tickets filtrados (IndexWithFilter).

Se modifica la vista **Filter_Tickets** para agregar un cuadro de diálogo explicando el funcionamiento del filtro al usuario, además de que si se presentan fallas al realizar el filtrado (seleccionar los checkbox de incluir cerrados y solo cerrados al mismo tiempo, si se ingresa un parámetro no válido o si no hay resultados para los filtros aplicados), se incorpora un mensaje debajo del título que alerte del problema.

Se eliminan espacios extra en **AccesoController.cs**.

En **TicketsController**:
Se llaman los paquetes necesarios para la paginación de tickets en **IndexWithFilter**.
El método **Filter_Ticket**: De tipo GET muestra la página donde el usuario aplica los filtros para buscar los tickets y se inicializan las listas que necesita la vista. El de tipo POST recibe los parámetros de Filter y Page, es decir los campos del formulario de filtrado y el número de página para la paginación, de ser necesario. Redirecciona a IndexWithFilter, este método valida los filtros seleccionados y construye la URL para que IndexWithFilter pueda mostrar los resultados.
El método **IndexWithFilter**: El de tipo Get aplica los filtros recibidos en la URL del formulario para hacer las consultas a los tickets, y manda este modelo a la vista ya paginados.
Se corrige la lógica de Incluir Tickets Cerrados y Solo Cerrados (is_closed, just_closed), para que funcione correctamente.

Se modifica la vista **IndexWithFilter** para que reciba la lista paginada de tickets, del tipo TicketViewModel que viene desde el controller, muestra la tabla con los datos (ID, Título, Estatus, Usuario, Subsistema, Terminal y botón para mas detalles) y genera la paginación de los tikcets filtrados.
Los links de paginación se generan con los filtros seleccionados, ya que se almacenan en ViewBags y así permite cambiar de página integrando correctamente los filtros aplicados.

**Funcionamiento**:
Se puede aplicar múltiples filtros para buscar tickets específicos. Marcando los checkboxes que quieras activar (como ID, Usuario, Terminal, etc.), y seleccionando sus valores correspondientes.
Los filtros se combinan: se mostrarán solo los tickets que cumplan todas las condiciones marcadas.
Ejemplo 1:Si se elige ID = 23 y Terminal = TAD Hermosillo, se mostrará el ticket 23 solo si pertenece a esa terminal.
Ejemplo 2:Si se selecciona Usuario = Carter y Terminal = TAD Hermosillo, verás solo los tickets de Carter en esa terminal.
Si no hay coincidencias con los filtros marcados, no se mostrará ningún ticket.
Además, se pueden usar las siguientes opciones para incluir tickets cerrados: Incluir Tickets cerrados: Agrega al resultado los tickets que ya fueron finalizados. Solo Tickets cerrados: Muestra únicamente los tickets que están cerrados.